### PR TITLE
Fix grammar and phrasing in Arsink malware report

### DIFF
--- a/docs/source/malware_report.rst
+++ b/docs/source/malware_report.rst
@@ -1621,7 +1621,7 @@ The table below lists the APKs we tested.
 New Quark Rules For Arsink
 ==========================
 
-New Quark rule (#00271) is now available. This rule targets `Arsink <https://malpedia.caad.fkie.fraunhofer.de/details/apk.arsink>`__. The Arsink malware family is a type of Android malware that primarily targets users by leveraging various malicious behaviors, including sending SMS messages without user consent and accessing sensitive device information. It is often disguised as a legitimate application to evade detection and gain unauthorized access to user data. Check `here <https://github.com/quark-engine/quark-rules>`__ for the rule details.
+A new Quark rule (#00271) is now available. This rule targets `Arsink <https://malpedia.caad.fkie.fraunhofer.de/details/apk.arsink>`__. The Arsink malware family is a type of Android malware that targets users through various malicious behaviors, including sending SMS messages without user consent and accessing sensitive device information. It is often disguised as a legitimate application to evade detection and gain unauthorized access to user data. See the `quark-rules repository <https://github.com/quark-engine/quark-rules>`__ for the rule details.
 
 With these rules, Quark is now able to identify the Arsink malware family as high-risk. In our experiment, Quark achieved 100% accuracy and 100% precision. Please check :ref:`here <list-of-tested-apks-arsink>` for the APKs we tested.
 
@@ -1632,7 +1632,7 @@ Below is a summary report of an Arsink sample (``06F7DFDFBFF03719082750FB11CA1F1
 Identified Well-Known Threats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With Quark's rule classification feature, analysts can generate behavior maps and see how behaviors are related. This feature helps identify 3 well-known threats from Arsink, as shown below.
+With Quark's rule classification feature, analysts can generate behavior maps and see how behaviors are related. This feature helps identify 3 well-known threats associated with Arsink, as shown below.
 
 **1. Accessing Device Information**
 
@@ -1649,10 +1649,10 @@ Behaviors detected by Quark:
 * Query device data with ContentResolver and a URI parsed from a string (#00222)
 * Accessing sensitive data from content provider (#00271)
 
-**2. Intercepting Sms Messages**
+**2. Intercepting SMS Messages**
 
 .. image:: https://i.ibb.co/HDv1R0GQ/intercepting-sms-messages.png
-   :alt: Intercepting Sms Messages
+   :alt: Intercepting SMS Messages
 
 The behavior map reveals that the ``LSay/hello/To/Arthur/FileUtil;convertUriToFilePath`` function queries SMS and call log data from URIs, and invokes ``LSay/hello/To/Arthur/FileUtil;getDataColumn`` to read this sensitive data, enabling SMS interception.
 


### PR DESCRIPTION
## Summary
Corrects several prose issues in the Arsink section of `docs/source/malware_report.rst`. No semantic/content changes — purely grammar, article usage, and acronym capitalization.

## Changes
- Add missing article: `New Quark rule` → `A new Quark rule`
- Simplify phrasing: `primarily targets users by leveraging various malicious behaviors` → `targets users through various malicious behaviors`
- Use descriptive link text: `Check` `here` → `See the` `quark-rules repository`
- More precise attribution: `3 well-known threats from Arsink` → `3 well-known threats associated with Arsink`
- Capitalize acronym: `Intercepting Sms Messages` → `Intercepting SMS Messages` (heading + image alt text)

## Test plan
- [ ] Build the Sphinx docs and confirm the Arsink section renders without warnings
- [ ] Verify the `quark-rules repository` hyperlink still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)